### PR TITLE
Temporary fix for image path in scss for build

### DIFF
--- a/src/app/welcome-panel/welcome-panel.component.scss
+++ b/src/app/welcome-panel/welcome-panel.component.scss
@@ -7,7 +7,7 @@
     justify-content: center;
     align-items:flex-end;
     background: rgb(121, 121, 121);
-    background-image: url('/assets/images/welcome.jpg');
+    background-image: url("../../assets/images/welcome.jpg");
     background-blend-mode: darken;
     background-size: cover;
     background-position: center;


### PR DESCRIPTION
- Quick fix for splash screen's image path in the scss. Change to using relative path for background image in scss file.
  - Note that this seems to break local dev environment's rendering of image when changes are made to the site while using `ng serve` so it is only a temporary fix.
  - Can theoretically move to absolute path (like how it is currently) once forked onto CSSA's repo.